### PR TITLE
Feature/caching details

### DIFF
--- a/slc/routes.py
+++ b/slc/routes.py
@@ -26,8 +26,7 @@ __routes__ = [
     ),
     Route(
         "/soutiens",
-        GET=templated_page,
-        template="default/soutiens.html",
+        GET="slc.views.soutiens",
         name="soutiens",
     ),
     Route(

--- a/slc/views.py
+++ b/slc/views.py
@@ -50,7 +50,7 @@ def petition_count(request):
     )
     return Response(
         request.format(count)
-    ).add_headers(cache_control="must-revalidate, max-age=30", vary="cookie")
+    ).add_headers(cache_control="must-revalidate, max-age=10", vary="cookie")
 
 def support_us_email(request):
 

--- a/slc/views.py
+++ b/slc/views.py
@@ -26,7 +26,7 @@ def homepage(request):
     return piglet.render(
         "default/index.html",
         {"days_left": (options.CONVENTION_DATE - request.now.date()).days - 1},
-    ).add_headers(cache_control="must-revalidate, max-age=29", vary="cookie")
+    ).add_headers(cache_control="must-revalidate, max-age=600", vary="cookie")
 
 
 def templated_page(request, template):

--- a/slc/views.py
+++ b/slc/views.py
@@ -33,6 +33,12 @@ def templated_page(request, template):
     return piglet.render(template, {})
 
 
+def soutiens(request):
+    return piglet.render(
+        "default/soutiens.html", {}
+    ).add_headers(cache_control="must-revalidate, max-age=600", vary="cookie")
+
+
 def support_us(request):
     return piglet.render("default/support-us.html", {})
 


### PR DESCRIPTION
Increase caching for full page to 10 min
Decrease caching for count to 10 sec

Goal is to make sure that a user that fills the support form sees that his support was added to the tally at step 4.

What do you think ?